### PR TITLE
Use entry_key as CSL JSON id

### DIFF
--- a/src/export/csl.js
+++ b/src/export/csl.js
@@ -70,7 +70,7 @@ export class CSLExporter {
         for (let bibId in this.bibDB) {
             if (this.pks.indexOf(bibId) !== -1) {
                 this.cslDB[bibId] = this.getCSLEntry(bibId)
-                this.cslDB[bibId].id = bibId
+                this.cslDB[bibId].id = this.bibDB[bibId].entry_key
             }
         }
         return this.cslDB


### PR DESCRIPTION
This is a naive fix for #98, which works for [my needs](https://github.com/hubgit/bibtex-loader) but may have unforeseen effects on other use cases. 

If it's potentially problematic, maybe it could be configurable by passing an option to `CSLExporter`.

closes #98