### PR TITLE
Add `journal` for `misc` type

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -866,7 +866,7 @@ export const BibTypes = {
         "csl": "entry",
         "required": ["title", "date"],
         "eitheror": ["editor", "author"],
-        "optional": ["abstract", "addendum", "howpublished", "type", "pubstate", "organization", "doi", "subtitle", "language", "langid", "location", "url", "urldate", "titleaddon", "version", "note", "eprint", "eprintclass", "eprinttype", "annotation", "keywords"]
+        "optional": ["abstract", "addendum", "howpublished", "type", "pubstate", "journal", "organization", "doi", "subtitle", "language", "langid", "location", "url", "urldate", "titleaddon", "version", "note", "eprint", "eprintclass", "eprinttype", "annotation", "keywords"]
     },
     "online": {
         "order": 42,


### PR DESCRIPTION
Some people use `journal` in `@misc{}` items. Currenty if I parse this:

```bibtex
@misc{dehut_en_2018,
      type = {Billet},
      journal = {L’atelier des savoirs},
      file = {Snapshot:/home/antoine/Zotero/storage/VC32TEFF/Dehut - En finir avec Word ! Pour une analyse des enjeux r.html:text/html}
}
```

… it would be lost in the export as it is not an allowed property in the output:

```bibtex
@misc{dehut_en_2018,
      type = {Billet}
}
```

I have not seen an exporter option to allow "unknown" fields. I can withdraw this PR if something like this exists, that I would have missed.

cc @mogztter
refs EcrituresNumeriques/stylo#187