### PR TITLE
Allow to export unexpected fields in BibLatexExporter

### DIFF
--- a/src/export/biblatex.js
+++ b/src/export/biblatex.js
@@ -25,6 +25,7 @@ import type {NodeArray, RangeArray, NameDictObject} from "../const"
 
 type ConfigObject = {
     traditionalNames?: boolean;
+    exportUnexpectedFields?: boolean;
 };
 
 type BibObject = {
@@ -81,11 +82,12 @@ export class BibLatexExporter {
             if (BibTypes[bib['bib_type']]['biblatex-subtype']) {
                 fValues['entrysubtype'] = BibTypes[bib['bib_type']]['biblatex-subtype']
             }
-            for (let fKey in bib.fields) {
+            const fields = this.config.exportUnexpectedFields ? {...bib.fields, ...bib.unexpected_fields} : bib.fields
+            for (let fKey in fields) {
                 if (!BibFieldTypes[fKey]) {
                     continue
                 }
-                let fValue = bib.fields[fKey]
+                let fValue = fields[fKey]
                 let fType = BibFieldTypes[fKey]['type']
                 let key = BibFieldTypes[fKey]['biblatex']
                 switch (fType) {
@@ -127,7 +129,6 @@ export class BibLatexExporter {
                     default:
                         console.warn(`Unrecognized type: ${fType}!`)
                 }
-
             }
             bibEntry.values = fValues
             this.bibtexArray[this.bibtexArray.length] = bibEntry


### PR DESCRIPTION
Adds a `exportUnexpectedFields` config to export `unexpected_fields`:


```js
const bibtext = `@misc{dehut_en_2018,
      type = {Billet},
      title = {En finir avec {Word} ! {Pour} une analyse des enjeux relatifs aux traitements de texte et à leur utilisation},
      url = {https://eriac.hypotheses.org/80},
      abstract = {Le titre de ce billet aurait pu être formé autour d’une expression célèbre attribuée à Caton l’ancien : delenda carthago[1], il faut détruire Carthage. Citation dont on trouve notamment un écho chez Plutarque[2] qui relate...},
      language = {fr-FR},
      urldate = {2018-03-29},
      journal = {L’atelier des savoirs},
      author = {Dehut, Julien},
      month = jan,
      year = {2018},
      file = {Snapshot:/home/antoine/Zotero/storage/VC32TEFF/Dehut - En finir avec Word ! Pour une analyse des enjeux r.html:text/html}
    }`
const {entries} = new BibLatexParser(bibtex, { processUnexpected: true, processUnknown: true }).parse()
const result = new BibLatexExporter(entries, false, { exportUnexpectedFields: true }).parse()
console.log(result)
```

**Output with exportUnexpectedFields**
```
@misc{dehut_en_2018,
    date = {2018-01},
    type = {Billet},
    title = {En finir avec {{Word}} ! {{Pour}} une analyse des enjeux relatifs aux traitements de texte et à leur utilisation},
    url = {https://eriac.hypotheses.org/80},
    abstract = {Le titre de ce billet aurait pu être formé autour d’une expression célèbre attribuée à Caton l’ancien : delenda carthago[1], il faut détruire Carthage. Citation dont on trouve notamment un écho chez Plutarque[2] qui relate...},
    language = {fr-FR},
    urldate = {2018-03-29},
    author = {given={Julien}, family={Dehut}},
    journaltitle = {L’atelier des savoirs},
    file = {Snapshot:/home/antoine/Zotero/storage/VC32TEFF/Dehut - En finir avec Word ! Pour une analyse des enjeux r.html:text/html}
    }
```

**Output without exportUnexpectedFields**
```
@misc{dehut_en_2018,
    date = {2018-01},
    type = {Billet},
    title = {En finir avec {{Word}} ! {{Pour}} une analyse des enjeux relatifs aux traitements de texte et à leur utilisation},
    url = {https://eriac.hypotheses.org/80},
    abstract = {Le titre de ce billet aurait pu être formé autour d’une expression célèbre attribuée à Caton l’ancien : delenda carthago[1], il faut détruire Carthage. Citation dont on trouve notamment un écho chez Plutarque[2] qui relate...},
    language = {fr-FR},
    urldate = {2018-03-29},
    author = {given={Julien}, family={Dehut}}
    }
```

`file` and `journaltitle` are missing.


resolves #112 