### PR TITLE
When calculating `bibType`, consider the exact match first

### DIFF
--- a/src/import/biblatex.ts
+++ b/src/import/biblatex.ts
@@ -952,13 +952,22 @@ export class BibLatexParser {
             }
         }
 
-        let bibType = Object.keys(BibTypes).find((bType) => {
-            return (
-                BibTypes[bType]["biblatex"] === biblatexType &&
-                (!biblatexSubtype ||
-                    BibTypes[bType]["biblatex-subtype"] === biblatexSubtype)
-            )
-        })
+        let bibType
+        if (
+            biblatexType in BibTypes &&
+            (!biblatexSubtype ||
+                BibTypes[biblatexType]["biblatex-subtype"] === biblatexSubtype)
+        ) {
+            bibType = biblatexType
+        } else {
+            bibType = Object.keys(BibTypes).find((bType) => {
+                return (
+                    BibTypes[bType]["biblatex"] === biblatexType &&
+                    (!biblatexSubtype ||
+                        BibTypes[bType]["biblatex-subtype"] === biblatexSubtype)
+                )
+            })
+        }
 
         if (typeof bibType === "undefined") {
             this.warning({


### PR DESCRIPTION
Hey there,

Thank you for this excellent library!

There is one issue I'd love to address in this PR. I stumbled on it, trying to parse the following bib item:

```bibtex
@online{eleventy,
  title = {Eleventy Is a Simpler Static Site Generator},
  author = {Leatherman, Zach},
  url = {https://www.11ty.dev/},
  urldate = {2024-07-22}
}
```

Currently, for this item, the parser returns the `post-weblog` type since it's the first one for which the following condition is `true`:

https://github.com/fiduswriter/biblatex-csl-converter/blob/1a9c5903e7bdf517bcc61e0d61b8befbea91f21e/src/import/biblatex.ts#L957-L959

However, there is the exact (and expected) match for this bib item among all the supported types:

https://github.com/fiduswriter/biblatex-csl-converter/blob/1a9c5903e7bdf517bcc61e0d61b8befbea91f21e/src/const.ts#L1708-L1731

It would be nice if we could check for the exact match first (and return the corresponding type if it succeeded) before trying to find the most appropriate type and fall back to `misc` if everything fails.

What do you think?